### PR TITLE
Pagination on Ministry Profile Page and Payment Factory

### DIFF
--- a/app/Http/Controllers/MinistryController.php
+++ b/app/Http/Controllers/MinistryController.php
@@ -12,12 +12,12 @@ class MinistryController extends Controller
 {
     public function getMinistries($ministries)
     {
-        $currentYr = date("Y").'-01-01';
+        $currentYr = date("Y");
         foreach ($ministries as $ministry) {
             $code = $ministry->code;
             $payments = DB::table('payments')
                         ->where('payment_code', 'LIKE', "$code%")
-                        ->where('payment_date', '>=', "$currentYr")
+                        ->whereYear('payment_date', '=', "$currentYr")
                         ->get();
             $total = $payments->sum('amount');
             $ministry->total = $total;
@@ -33,17 +33,6 @@ class MinistryController extends Controller
         $ministries = $this->getMinistries($data);
         return view('pages.ministry.index')->with('ministries', $ministries);
     }
-
-     /**
-     * Re-renders all the ministries each time the search box's content is cleared
-     * Was getting 404 error, Moved back to MinistrySearchController
-     */
-    // public function index()
-    // {
-    //     $data = Ministry::all();
-    //     $ministries = $this->getMinistries($data);
-    //     echo $ministries;
-    // }
 
     /**
      * Show the form for creating a new resource.
@@ -74,45 +63,55 @@ class MinistryController extends Controller
     }
 
     /**
+     * Gets the total expenditure for each of last 5 years
+     */
+    public function fiveYearTrend($code)
+    {
+        $payments = DB::table('payments')
+                    ->where('payment_code', 'LIKE', "$code%")
+                    ->orderby('payment_date', 'desc')
+                    ->get();
+        $currentYr = date("Y");
+        $years = [$currentYr, $currentYr - 1, $currentYr - 2, $currentYr - 3, $currentYr - 4];
+        $yearByYear = [];
+        for ($x = 0; $x < count($years); $x++) {
+            $filtered = $payments->filter(function ($value, $key) use (&$years, $x) {
+                return date('Y', strtotime($value->payment_date)) == $years[$x];
+            });
+            if($x == 0){
+                $count = count($filtered);
+            }
+            $sum = $filtered->sum('amount'); 
+            $yearByYear[$years[$x]] = $sum;
+        }
+        return [$count, $yearByYear];
+    }
+
+    /**
      * Display the specified resource.
      * Called when user clicks on a ministry card in index.blade.php
      */
     public function show(Ministry $ministry)
     {
-            $code = $ministry->code;
-            $cabinets = $ministry->cabinet;
-            $payments = DB::table('payments')
-                        ->where('payment_code', 'LIKE', "$code%")
-                        ->orderby('payment_date', 'desc')
-                        ->get();
-
-        function getTrend($payments)
-        {
-            $currentYr = date("Y");
-            $years = [$currentYr, $currentYr - 1, $currentYr - 2, $currentYr - 3, $currentYr - 4];
-            $yearByYear = [];
-            $currentYrPmts = [];
-            for ($x = 0; $x < count($years); $x++) {
-                $filtered = $payments->filter(function ($value, $key) use (&$years, $x) {
-                    return date('Y', strtotime($value->payment_date)) == $years[$x];
-                });
-                if ($x == 0) {
-                    $currentYrPmts = $filtered;
-                }
-                $sum = $filtered->sum('amount');
-                $yearByYear[$years[$x]] = $sum;
-            }
-            return [$currentYrPmts, $yearByYear];
-        }
-
-            $data = getTrend($payments);
-            return view('pages.ministry.single')
-            ->with(['ministry'=> $ministry,
-                    'cabinets' => $cabinets,
-                    'payments' => $data[0],
-                    'trend' => $data[1]
-                 ]);
+        $code = $ministry->code;
+        $cabinets = $ministry->cabinet;
+        $yr = date("Y");
+        $payments = DB::table('payments')
+                    ->where('payment_code', 'LIKE', "$code%")
+                    ->whereYear('payment_date', '=', "$yr")
+                    ->orderby('payment_date', 'desc')
+                    ->paginate(2);
+    
+        $data = $this->fiveYearTrend($code);
+        return view('pages.ministry.single')
+        ->with(['ministry'=> $ministry,
+                'cabinets' => $cabinets,
+                'payments' => $payments,
+                'trend' => $data[1],
+                'count' => $data[0]
+                ]);
     }
+
 
     /**
      * Show the form for editing the specified resource.

--- a/app/Payment.php
+++ b/app/Payment.php
@@ -17,7 +17,7 @@ class Payment extends Model
      */
     public function ministry(){
         $ministryCode = substr($this->payment_code, 0, 4); //ministry code is first 4 digits in a payment code
-        $ministry = Ministry::where('code', 'LIKE', "%$ministryCode%")->get()[0]->only(['shortname', 'name']);
+        $ministry = Ministry::where('code', 'LIKE', "$ministryCode%")->get()[0]->only(['shortname', 'name']);
         return $ministry; //return array keyed ['name' => '', 'shortname' => '']
     }
 }

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -6,14 +6,22 @@ use App\Payment;
 use Faker\Generator as Faker;
 
 $factory->define(Payment::class, function (Faker $faker) {
+    $dt = $faker->dateTimeBetween('-4 years', 'now');
+    $codes = [
+                '0116','0119','0123','0124','0155','0156','0164',
+                '0215','0220','0222','0227','0228','0229','0230',
+                '0231','0232','0233','0234','0252','0326','0437',
+                '0451','0513','0514','0517','0521','0535','0544'
+            ];
+
     return [
-        //
-        'payment_no' =>$faker->randomNumber(300),
-        'payer_code' =>$faker->randomDigit,
-        'organization' =>$faker->lastName,
-        'beneficiary' =>$faker->firstName,
-        'amount' =>$faker->randomNumber(4),
-        'payment_date' =>$faker->date_date_set,
-        'description' =>$faker->paragraph,
+        'payment_no' => $faker->randomNumber(5, true).$faker->randomNumber(5, true)."-".$faker->randomNumber(2, true),
+        'payment_code' => $faker->randomElement($codes).$faker->randomNumber(6, true),
+        'organization' => $faker->company,
+        'beneficiary' => $faker->company,
+        'amount' => $faker->numberBetween(1000000,1000000000),
+        'payment_date' =>  $dt->format('Y-m-d'),
+        'description' => $faker->paragraph(1)
     ];
+    
 });

--- a/database/seeds/PaymentSeeder.php
+++ b/database/seeds/PaymentSeeder.php
@@ -13,353 +13,357 @@ class PaymentSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('payments')->insert([
-            [
-                "payment_no" => "1000660807-20",
-                "payment_code" => "0124001001",
-                "organization" => "Interior",
-                "beneficiary" => "JAY JAY BADMUS INVESTMENT LTD",
-                "description"=> "Allowances Paid Minister to travel for International Conference",
-                "amount"=> 3200000,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-21",
-                "payment_code" => "0232001002",
-                "organization" => "Petroleum",
-                "beneficiary" => "Dangote Group",
-                "description"=> "Repair of Niger Delta Pipeline",
-                "amount"=> 45000000,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-22",
-                "payment_code" => "0231001003",
-                "organization" => "Power",
-                "beneficiary" => "WATERBASE ENGINEERING LIMITED",
-                "description"=> "Construction of Power Plant in Ogun State",
-                "amount"=> 87500000,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-23",
-                "payment_code" => "0234001004",
-                "organization" => "Works & Housing",
-                "beneficiary" => "AKINYOSOYE  OLADOTUN",
-                "description"=> "Rehabilitation of Senate Building",
-                "amount"=> 32800000,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-24",
-                "payment_code" => "0234001005",
-                "organization" => "Works & Housing",
-                "beneficiary" => "AKINYOSOYE  OLADOTUN",
-                "description"=> "Contract for Aso Villa Interior rehabilitation",
-                "amount"=> 46700000,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-25",
-                "payment_code" => "0521001006",
-                "organization" => "Health",
-                "beneficiary" => "GEOID CONSULT LTD",
-                "description"=> "Payment for items for COVID-19 outbreak",
-                "amount"=> 27671024.12,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-26",
-                "payment_code" => "0231001008",
-                "organization" => "Power",
-                "beneficiary" => "MARITIME PROJECT SERVICES LIMITED",
-                "description"=> "CONSTRUCTION OF 60KW SOLAR MINI GRIDS IN TAKUM",
-                "amount"=> 57869120.98,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
-            [
-                "payment_no" => "1000660807-27",
-                "payment_code" => "0234001009",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Dangote Group",
-                "description"=> "CEMENT SUPPLY FOR NEW MINISTRY OFFICE COMPLEX CONSTRUCTION",
-                "amount"=>57869120.98,
-                "payment_date"=> Carbon::create('2019', '11', '04')
-            ],
+
+        $payment = factory(\App\Payment::class, 1000)->create();
+
+
+        // DB::table('payments')->insert([
+        //     [
+        //         "payment_no" => "1000660807-20",
+        //         "payment_code" => "0124001001",
+        //         "organization" => "Interior",
+        //         "beneficiary" => "JAY JAY BADMUS INVESTMENT LTD",
+        //         "description"=> "Allowances Paid Minister to travel for International Conference",
+        //         "amount"=> 3200000,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-21",
+        //         "payment_code" => "0232001002",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Dangote Group",
+        //         "description"=> "Repair of Niger Delta Pipeline",
+        //         "amount"=> 45000000,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-22",
+        //         "payment_code" => "0231001003",
+        //         "organization" => "Power",
+        //         "beneficiary" => "WATERBASE ENGINEERING LIMITED",
+        //         "description"=> "Construction of Power Plant in Ogun State",
+        //         "amount"=> 87500000,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-23",
+        //         "payment_code" => "0234001004",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "AKINYOSOYE  OLADOTUN",
+        //         "description"=> "Rehabilitation of Senate Building",
+        //         "amount"=> 32800000,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-24",
+        //         "payment_code" => "0234001005",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "AKINYOSOYE  OLADOTUN",
+        //         "description"=> "Contract for Aso Villa Interior rehabilitation",
+        //         "amount"=> 46700000,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-25",
+        //         "payment_code" => "0521001006",
+        //         "organization" => "Health",
+        //         "beneficiary" => "GEOID CONSULT LTD",
+        //         "description"=> "Payment for items for COVID-19 outbreak",
+        //         "amount"=> 27671024.12,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-26",
+        //         "payment_code" => "0231001008",
+        //         "organization" => "Power",
+        //         "beneficiary" => "MARITIME PROJECT SERVICES LIMITED",
+        //         "description"=> "CONSTRUCTION OF 60KW SOLAR MINI GRIDS IN TAKUM",
+        //         "amount"=> 57869120.98,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-27",
+        //         "payment_code" => "0234001009",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Dangote Group",
+        //         "description"=> "CEMENT SUPPLY FOR NEW MINISTRY OFFICE COMPLEX CONSTRUCTION",
+        //         "amount"=>57869120.98,
+        //         "payment_date"=> Carbon::create('2019', '11', '04')
+        //     ],
             
-            [
-                "payment_no" => "1000660807-28",
-                "payment_code" => "0232001031",
-                "organization" => "Petroleum",
-                "beneficiary" => "Mr. Oluwatosin Kamoru  Osijirin",
-                "amount" => 6958234.15,
-                "description" => "Import Duties",
-                "payment_date" => Carbon::create('2019', '02', '01')
-            ],
-            [
-                "payment_no" => "1000660807-29",
-                "payment_code" => "0234001601",
-                "organization" => "Works & Housing",
-                "beneficiary" => "CCCEC",
-                "amount" => 8175491.12,
-                "description" => "40km Rail Project Milestone 1",
-                "payment_date" => Carbon::create('2020', '03', '04')
-            ],
-            [
-                "payment_no" => "1000660807-30",
-                "payment_code" => "0517001901",
-                "organization" => "Education",
-                "beneficiary" => "Ziang Foods",
-                "amount" => 5612669.77,
-                "description" => "School Feeding Program Batch 1",
-                "payment_date" => Carbon::create('2018', '03', '01')
-            ],
-            [
-                "payment_no" => "1000660807-31",
-                "payment_code" => "0517071001",
-                "organization" => "Education",
-                "beneficiary" => "Mr. Emmanuel Okpo Onukak",
-                "amount" => 5469294.84,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2018', '04', '01')
-            ],
-            [
-                "payment_no" => "1000660807-32",
-                "payment_code" => "0234006201",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Joe and Sons",
-                "amount" => 5443063.80,
-                "description" => "Renovation of FHA estate, kwali",
-                "payment_date" => Carbon::create('2019', '09', '09')
-            ],
-            [
-                "payment_no" => "1000660807-33",
-                "payment_code" => "0232001457",
-                "organization" => "Petroleum",
-                "beneficiary" => "Engr. Micheal Ayodeji Dada",
-                "amount" => 7889871.57,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2020', '04', '02')
-            ],
-            [
-                "payment_no" => "1000660807-34",
-                "payment_code" => "0234001001",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Jobeg Constructors",
-                "amount" => 217049880.64,
-                "description" => "Low-cost Federal Housing Estate",
-                "payment_date" => Carbon::create('2019', '05', '11')
-            ],
-            [
-                "payment_no" => "1000660807-35",
-                "payment_code" => "0517001521",
-                "organization" => "Education",
-                "beneficiary" => "Mr. Olamide Titus Ajayi",
-                "amount" => 5561063.72,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2020', '01', '01')
-            ],
-            [
-                "payment_no" => "1000660807-36",
-                "payment_code" => "0517002001",
-                "organization" => "Education",
-                "beneficiary" => "Mr. Joseph Olabode Oge",
-                "amount" => 5762487.54,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2020', '03', '21')
-            ],
-            [
-                "payment_no" => "1000660807-37",
-                "payment_code" => "0234008601",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Mr. Francis Itegbe",
-                "amount" => 7917837.13,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2019', '04', '04')
-            ],
-            [
-                "payment_no" => "1000660807-38",
-                "payment_code" => "0517001571",
-                "organization" => "Education",
-                "beneficiary" => "Mr. Pascal Okechukwu Ndubuisi",
-                "amount" => 7535342.20,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2019', '02', '01')
-            ],
-            [
-                "payment_no" => "1000660807-39",
-                "payment_code" => "0234001231",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
-                "amount" => 7914455.37,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2020', '02', '01')
-            ],
-            [
-                "payment_no" => "1000660807-40",
-                "payment_code" => "0517001056",
-                "organization" => "Education",
-                "beneficiary" => "Ziang Foods",
-                "amount" => 5612669.77,
-                "description" => "School Feeding Program Batch 3",
-                "payment_date" => Carbon::create('2019', '13', '01')
-            ],
-            [
-                "payment_no" => "1000660807-41",
-                "payment_code" => "0231001981",
-                "organization" => "Petroleum",
-                "beneficiary" => "Mrs. Edu Victor Antai",
-                "amount" => 6721612.26,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2019', '02', '01')
-            ],
-            [
-                "payment_no" => "1000660807-42",
-                "payment_code" => "0231001451",
-                "organization" => "Petroleum",
-                "beneficiary" => "Kamuru Imports",
-                "amount" => 16958234.15,
-                "description" => "Fuel Subsidy",
-                "payment_date" => Carbon::create('2020', '04', '01')
-            ],
-            [
-                "payment_no" => "1000660807-43",
-                "payment_code" => "0234001029",
-                "organization" => "Works & Housing",
-                "beneficiary" => "CCCEC",
-                "amount" => 5778413.63,
-                "description" => "Lagos-Ibadan Phase II",
-                "payment_date" => Carbon::create('2020', '03', '01')
-            ],
-            [
-                "payment_no" => "1000660807-44",
-                "payment_code" => "0231001030",
-                "organization" => "Petroleum",
-                "beneficiary" => "Haliburton Int'l",
-                "amount" => 126958234.15,
-                "description" => "Turn Around Maintenance",
-                "payment_date" => Carbon::create('2020', '02', '01')
-            ],
-            [
-                "payment_no" => "1000660807-46",
-                "payment_code" => "0234001061",
-                "organization" => "Works & Housing",
-                "beneficiary" => "CCCEC",
-                "amount" => 5778413.63,
-                "description" => "Lagos-Ibadan Phase I",
-                "payment_date" => Carbon::create('2020', '03', '01')
-            ],
-            [
-                "payment_no" => "1000660807-47",
-                "payment_code" => "0234001062",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Julius Berger",
-                "amount" => 235778413.63,
-                "description" => "Oshodi-Apapa express",
-                "payment_date" => Carbon::create('2020', '05', '01')
-            ],
-            [
-                "payment_no" => "1000660807-48",
-                "payment_code" => "0234001078",
-                "organization" => "Works & Housing",
-                "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
-                "amount" => 207094208.37,
-                "description" => "3rd Mainland Bridge - routine maintenance",
-                "payment_date" => Carbon::create('2018', '12', '20')
-            ],
-            [
-                "payment_no" => "1000660807-49",
-                "payment_code" => "0517001008",
-                "organization" => "Education",
-                "beneficiary" => "Ziang Foods",
-                "amount" => 5612669.77,
-                "description" => "School Feeding Program Batch B",
-                "payment_date" => Carbon::create('2018', '05', '01')
-            ],
-            [
-                "payment_no" => "1000660807-50",
-                "payment_code" => "0232001048",
-                "organization" => "Petroleum",
-                "beneficiary" => "Mrs. Edu Victor  Antai",
-                "amount" => 6721612.26,
-                "description" => "STAFF HOUSING AND COLA 2020",
-                "payment_date" => Carbon::create('2018', '09', '06')
-            ],
-            [
-                "payment_no" => "1000660807-51",
-                "payment_code" => "0116001678",
-                "organization" => "MINISTRY OF DEFENCE - MOD HQTRS",
-                "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
-                "amount" => 207094208.37,
-                "description" => "3rd Mainland Bridge - routine maintenance",
-                "payment_date" => Carbon::create('2018', '12', '20')
-            ],
-            [
-                "payment_no" => "1000660807-52",
-                "payment_code" => "0116001018",
-                "organization" => "NIGERIAN AIRFORCE",
-                "beneficiary" => "NAF 107 NIGERIAN AIR FORCE CAMP",
-                "amount" => 125473530.76,
-                "description" => "",
-                "payment_date" => Carbon::create('2018', '07', '01')
-            ],
-            [
-                "payment_no" => "1000660807-53",
-                "payment_code" => "0116001318",
-                "organization" => "NIGERIAN AIRFORCE",
-                "beneficiary" => "NAF TRAINING COMMAND",
-                "amount" => 886484303.64,
-                "description" => "",
-                "payment_date" => Carbon::create('2018', '05', '01')
-            ],
-            [
-                "payment_no" => "1000660807-54",
-                "payment_code" => "0116051019",
-                "organization" => "Defense",
-                "beneficiary" => "MINISTRY OF DEFENCE - MOD HQTRS",
-                "amount" => 6778912.00,
-                "description" => "Strategic Training I",
-                "payment_date" => Carbon::create('2020', '03', '26')
-            ],
-            [
-                "payment_no" => "1000660807-55",
-                "payment_code" => "0116101518",
-                "organization" => "MINISTRY OF DEFENCE - MOD HQTRS",
-                "beneficiary" => "CREATION CONSULT SOLUTIONS LTD",
-                "amount" => 6721612.26,
-                "description" => "Strategic Training II",
-                "payment_date" => Carbon::create('2018', '06', '06')
-            ],
-            [
-                "payment_no" => "1000660807-57",
-                "payment_code" => "0326006018",
-                "organization" => "FEDERAL MINISTRY OF JUSTICE - HQTRS",
-                "beneficiary" => "INYONYO ATABOR",
-                "amount" => 6511600.26,
-                "description" => "AUDIT QUERY RESPONSES REVIEW",
-                "payment_date" => Carbon::create('2017', '05', '16')
-            ],
-            [
-                "payment_no" => "1000660807-58",
-                "payment_code" => "0124041018",
-                "organization" => "NIGERIA CORRECTIONAL SERVICE",
-                "beneficiary" => "ALMUJAAFAR ENTERPRISES",
-                "amount" => 12129205.75,
-                "description" => "",
-                "payment_date" => Carbon::create('2019', '05', '16')
-            ],
-            [
-                "payment_no" => "1000660807-60",
-                "payment_code" => "0215071018",
-                "organization" => "NATIONAL CENTRE FOR AGRICULTURAL MECHANISATION- ILORIN",
-                "beneficiary" => "AJIBADE, ADEKUNLE NURUDEEN",
-                "amount" => 5877962,
-                "description" => "Construction and Equipping of Cassava and Rice Processing Sheds in Selected Communitiesin 6 Geopolitical Zones",
-                "payment_date" => Carbon::create('2019', '05', '16')
-            ],
+        //     [
+        //         "payment_no" => "1000660807-28",
+        //         "payment_code" => "0232001031",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Mr. Oluwatosin Kamoru  Osijirin",
+        //         "amount" => 6958234.15,
+        //         "description" => "Import Duties",
+        //         "payment_date" => Carbon::create('2019', '02', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-29",
+        //         "payment_code" => "0234001601",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "CCCEC",
+        //         "amount" => 8175491.12,
+        //         "description" => "40km Rail Project Milestone 1",
+        //         "payment_date" => Carbon::create('2020', '03', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-30",
+        //         "payment_code" => "0517001901",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Ziang Foods",
+        //         "amount" => 5612669.77,
+        //         "description" => "School Feeding Program Batch 1",
+        //         "payment_date" => Carbon::create('2018', '03', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-31",
+        //         "payment_code" => "0517071001",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Mr. Emmanuel Okpo Onukak",
+        //         "amount" => 5469294.84,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2018', '04', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-32",
+        //         "payment_code" => "0234006201",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Joe and Sons",
+        //         "amount" => 5443063.80,
+        //         "description" => "Renovation of FHA estate, kwali",
+        //         "payment_date" => Carbon::create('2019', '09', '09')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-33",
+        //         "payment_code" => "0232001457",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Engr. Micheal Ayodeji Dada",
+        //         "amount" => 7889871.57,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2020', '04', '02')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-34",
+        //         "payment_code" => "0234001001",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Jobeg Constructors",
+        //         "amount" => 217049880.64,
+        //         "description" => "Low-cost Federal Housing Estate",
+        //         "payment_date" => Carbon::create('2019', '05', '11')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-35",
+        //         "payment_code" => "0517001521",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Mr. Olamide Titus Ajayi",
+        //         "amount" => 5561063.72,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2020', '01', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-36",
+        //         "payment_code" => "0517002001",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Mr. Joseph Olabode Oge",
+        //         "amount" => 5762487.54,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2020', '03', '21')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-37",
+        //         "payment_code" => "0234008601",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Mr. Francis Itegbe",
+        //         "amount" => 7917837.13,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2019', '04', '04')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-38",
+        //         "payment_code" => "0517001571",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Mr. Pascal Okechukwu Ndubuisi",
+        //         "amount" => 7535342.20,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2019', '02', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-39",
+        //         "payment_code" => "0234001231",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
+        //         "amount" => 7914455.37,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2020', '02', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-40",
+        //         "payment_code" => "0517001056",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Ziang Foods",
+        //         "amount" => 5612669.77,
+        //         "description" => "School Feeding Program Batch 3",
+        //         "payment_date" => Carbon::create('2019', '13', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-41",
+        //         "payment_code" => "0231001981",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Mrs. Edu Victor Antai",
+        //         "amount" => 6721612.26,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2019', '02', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-42",
+        //         "payment_code" => "0231001451",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Kamuru Imports",
+        //         "amount" => 16958234.15,
+        //         "description" => "Fuel Subsidy",
+        //         "payment_date" => Carbon::create('2020', '04', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-43",
+        //         "payment_code" => "0234001029",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "CCCEC",
+        //         "amount" => 5778413.63,
+        //         "description" => "Lagos-Ibadan Phase II",
+        //         "payment_date" => Carbon::create('2020', '03', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-44",
+        //         "payment_code" => "0231001030",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Haliburton Int'l",
+        //         "amount" => 126958234.15,
+        //         "description" => "Turn Around Maintenance",
+        //         "payment_date" => Carbon::create('2020', '02', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-46",
+        //         "payment_code" => "0234001061",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "CCCEC",
+        //         "amount" => 5778413.63,
+        //         "description" => "Lagos-Ibadan Phase I",
+        //         "payment_date" => Carbon::create('2020', '03', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-47",
+        //         "payment_code" => "0234001062",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Julius Berger",
+        //         "amount" => 235778413.63,
+        //         "description" => "Oshodi-Apapa express",
+        //         "payment_date" => Carbon::create('2020', '05', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-48",
+        //         "payment_code" => "0234001078",
+        //         "organization" => "Works & Housing",
+        //         "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
+        //         "amount" => 207094208.37,
+        //         "description" => "3rd Mainland Bridge - routine maintenance",
+        //         "payment_date" => Carbon::create('2018', '12', '20')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-49",
+        //         "payment_code" => "0517001008",
+        //         "organization" => "Education",
+        //         "beneficiary" => "Ziang Foods",
+        //         "amount" => 5612669.77,
+        //         "description" => "School Feeding Program Batch B",
+        //         "payment_date" => Carbon::create('2018', '05', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-50",
+        //         "payment_code" => "0232001048",
+        //         "organization" => "Petroleum",
+        //         "beneficiary" => "Mrs. Edu Victor  Antai",
+        //         "amount" => 6721612.26,
+        //         "description" => "STAFF HOUSING AND COLA 2020",
+        //         "payment_date" => Carbon::create('2018', '09', '06')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-51",
+        //         "payment_code" => "0116001678",
+        //         "organization" => "MINISTRY OF DEFENCE - MOD HQTRS",
+        //         "beneficiary" => "Mrs. Margaret Kokomma Kelvin-Woluchem",
+        //         "amount" => 207094208.37,
+        //         "description" => "3rd Mainland Bridge - routine maintenance",
+        //         "payment_date" => Carbon::create('2018', '12', '20')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-52",
+        //         "payment_code" => "0116001018",
+        //         "organization" => "NIGERIAN AIRFORCE",
+        //         "beneficiary" => "NAF 107 NIGERIAN AIR FORCE CAMP",
+        //         "amount" => 125473530.76,
+        //         "description" => "",
+        //         "payment_date" => Carbon::create('2018', '07', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-53",
+        //         "payment_code" => "0116001318",
+        //         "organization" => "NIGERIAN AIRFORCE",
+        //         "beneficiary" => "NAF TRAINING COMMAND",
+        //         "amount" => 886484303.64,
+        //         "description" => "",
+        //         "payment_date" => Carbon::create('2018', '05', '01')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-54",
+        //         "payment_code" => "0116051019",
+        //         "organization" => "Defense",
+        //         "beneficiary" => "MINISTRY OF DEFENCE - MOD HQTRS",
+        //         "amount" => 6778912.00,
+        //         "description" => "Strategic Training I",
+        //         "payment_date" => Carbon::create('2020', '03', '26')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-55",
+        //         "payment_code" => "0116101518",
+        //         "organization" => "MINISTRY OF DEFENCE - MOD HQTRS",
+        //         "beneficiary" => "CREATION CONSULT SOLUTIONS LTD",
+        //         "amount" => 6721612.26,
+        //         "description" => "Strategic Training II",
+        //         "payment_date" => Carbon::create('2018', '06', '06')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-57",
+        //         "payment_code" => "0326006018",
+        //         "organization" => "FEDERAL MINISTRY OF JUSTICE - HQTRS",
+        //         "beneficiary" => "INYONYO ATABOR",
+        //         "amount" => 6511600.26,
+        //         "description" => "AUDIT QUERY RESPONSES REVIEW",
+        //         "payment_date" => Carbon::create('2017', '05', '16')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-58",
+        //         "payment_code" => "0124041018",
+        //         "organization" => "NIGERIA CORRECTIONAL SERVICE",
+        //         "beneficiary" => "ALMUJAAFAR ENTERPRISES",
+        //         "amount" => 12129205.75,
+        //         "description" => "",
+        //         "payment_date" => Carbon::create('2019', '05', '16')
+        //     ],
+        //     [
+        //         "payment_no" => "1000660807-60",
+        //         "payment_code" => "0215071018",
+        //         "organization" => "NATIONAL CENTRE FOR AGRICULTURAL MECHANISATION- ILORIN",
+        //         "beneficiary" => "AJIBADE, ADEKUNLE NURUDEEN",
+        //         "amount" => 5877962,
+        //         "description" => "Construction and Equipping of Cassava and Rice Processing Sheds in Selected Communitiesin 6 Geopolitical Zones",
+        //         "payment_date" => Carbon::create('2019', '05', '16')
+        //     ],
 
 
         
-        ]);
+        // ]);
     }
 }

--- a/public/css/ministry_list.css
+++ b/public/css/ministry_list.css
@@ -158,7 +158,7 @@ body{
 
 @media only screen and (min-width:550px){
   .money-spent .paragraph:before{
-    width:60%;
+    width:264px;
   }
 }
 @media only screen and (min-width:800px){
@@ -175,7 +175,7 @@ body{
     top:7%;
   }
   .money-spent .paragraph:before{
-    width:35%;
+    width:264px;
   }
 }
 @media only screen and (max-width:850px){

--- a/public/css/ministry_list_table.css
+++ b/public/css/ministry_list_table.css
@@ -357,8 +357,10 @@ text-align: center;
 
 .ui-datepicker-calendar { display: none; }
 #ui-datepicker-div{
-    position: absolute !important;
-    /* top: 410px !important; */
+    position: fixed !important;
+    top: 49% !important;
+    left: 44% !important;
+    transform: translate(-50%, -50%);
 }
 [data-handler="today"] {
     display: none

--- a/public/js/ministry_profile.js
+++ b/public/js/ministry_profile.js
@@ -104,10 +104,12 @@ $(document).ready(function() {
             }        
         });
 
+        let date, sort, active;
+
         $('#apply-filter').on('click', function(e){
             const id = $(this).attr("data-id");
             let invalid = false;
-            let date, sort, active;
+            
            
             if($('.btn-date.active').attr('id') === 'day'){
                 date = $('#select-date').val();
@@ -173,30 +175,58 @@ $(document).ready(function() {
                     data: data,
                     success: function(data){
                         
-                        data = JSON.parse(data)
-                        console.log(data)
-                        const {payments} = data
-                        let back = true;
-                        let html = "";
-                        if(payments.length > 0){
-                            for(payment of payments){
-                            back = !back;
-                            let shade = back ? 'back': '';
-                            html +=  `<tr  class="{shade}">
-                                        <td> ${payment.description}</td>
-                                        <td> ${payment.beneficiary}</td>
-                                        <td> ₦${insertCommas(payment.amount.toFixed(2))}</td>
-                                        <td> ${formatDate(payment.payment_date)}</td>
-                                    </tr>`                     
-                            }
-                        }else{
-                            html += `<b style="color: red">No data available for this day</b>`
-                        }
-                        let reportDate = /\d{4}-\d{2}-\d{2}/.test(data.givenTime)? formatDate(data.givenTime) : data.givenTime
+                        $('#tbl').html(data)
+
+                        // data = JSON.parse(data)
+                        // console.log(data)
+                        // const {payments} = data
+                        // let back = true;
+                        // let html = "";
+                        // if(payments.data.length > 0){
+                        //     for(payment of payments.data){
+                        //     back = !back;
+                        //     let shade = back ? 'back': '';
+                        //     html +=  `<tr  class="${shade}">
+                        //                 <td> ${payment.description}</td>
+                        //                 <td> ${payment.beneficiary}</td>
+                        //                 <td> ₦${insertCommas(payment.amount.toFixed(2))}</td>
+                        //                 <td> ${formatDate(payment.payment_date)}</td>
+                        //             </tr>`                     
+                        //     }
+                        // }else{
+                        //     html += `<b style="color: red">No data available for this day</b>`
+                        // }
+                        let reportDate = /\d{4}-\d{2}-\d{2}/.test(date)? formatDate(date) : date
                         $('#said-date').html(`Date: <span style="color:#1e7e34">${reportDate}</span>`)
                         $('#expense-table').html(html)
                     }
 
                 })
         })
+
+        $(document).on('click', '.pagination a', function(){
+            event.preventDefault();
+            let page = $(this).attr('href').split('page=')[1]
+            console.log(page)
+        //    console.log(date, sort)
+            fetch_data(page, date, sort)
+        })
+
+        function fetch_data(page, date, sort){
+            const id = $('#apply-filter').attr("data-id");
+            const data = {id, date, sort};
+            $.ajax({
+                url: "/ministry/filterExpenses?page="+page,
+                method: "GET",
+                data: data,
+                success: function(data){
+                    // console.log(data)
+                    $('#tbl').html(data)
+                    // console.log(data)
+                },
+                error: function(error){
+                    console.log(error)
+                }
+            })
+        }
     });

--- a/resources/views/pages/ministry/pagination.blade.php
+++ b/resources/views/pages/ministry/pagination.blade.php
@@ -1,0 +1,44 @@
+
+<div class="table-div">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th scope="col">Project</th>
+                <th scope="col">Company</th>
+                <th scope="col">Amount</th>
+                <th scope="col">Date</th>
+            </tr>
+        </thead>
+
+        <tbody id="expense-table">
+            @if (count($payments) > 0)
+                @php
+                $back = true;
+                @endphp
+                @foreach($payments as $payment)
+            
+                @php
+                $back = !$back;
+                $shade = $back ? 'back': '';
+                @endphp
+                    <tr  class="{{$shade}}">
+                        <td> {{$payment->description}}</td>
+                        <td> {{$payment->beneficiary}}</td>
+                        <td> ₦{{number_format($payment->amount, 2)}}</td>
+                        <td> {{date('jS, M Y', strtotime($payment->payment_date))}}</td>
+                    </tr>
+                @endforeach
+        @else
+            <tr><td></td><td style="color:red">No data available for this period<td><td></td></tr>  
+        @endif
+        
+        </tbody>
+
+    </table>
+
+</div>
+<div class="row centeri mzet-3 pt-3 pr-3 align-items-center">
+    <span class="col-md result text-muted">{{ $payments->firstItem() }} - {{ $payments->lastItem() }} of {{ $payments->total() }} results</span>
+    {{ $payments->links() }}
+</div>
+

--- a/resources/views/pages/ministry/single.blade.php
+++ b/resources/views/pages/ministry/single.blade.php
@@ -52,12 +52,12 @@
         </div>
         <div class="col">
             <p>Total Amount Spent</p>
-            <h4><span class="text-success">&#8358;{{number_format($trend["2020"], 2)}}</span></h4>
+            <h4><span class="text-success">&#8358;{{number_format($trend[date('Y')], 2)}}</span></h4>
             <small>{{date('Y')}}</small>
         </div>
         <div class="col">
             <p>Total Number of Projects</p>
-            <h4><span class="text-success">{{count($payments)}}</span></h4>
+            <h4><span class="text-success">{{$count}}</span></h4>
             <small>{{date('Y')}}</small>
         </div>
     </div>
@@ -153,58 +153,8 @@
                     </div>
                      <!-- End of Filter Modal -->
 
-                    <div class="container">
-                        <div class="table-div">
-                            <table class="table table-striped">
-                                <thead>
-                                    <tr>
-                                        <th scope="col">Project</th>
-                                        <th scope="col">Company</th>
-                                        <th scope="col">Amount</th>
-                                        <th scope="col">Date</th>
-                                    </tr>
-                                </thead>
-
-                                <tbody id="expense-table">
-                                    @if (count($payments) > 0)
-                                        @php
-                                        $back = true;
-                                        @endphp
-                                        @foreach($payments as $payment)
-                                    
-                                        @php
-                                        $back = !$back;
-                                        $shade = $back ? 'back': '';
-                                        @endphp
-                                            <tr  class="{{$shade}}">
-                                                <td> {{$payment->description}}</td>
-                                                <td> {{$payment->beneficiary}}</td>
-                                                <td> ₦{{number_format($payment->amount, 2)}}</td>
-                                                <td> {{date('jS, M Y', strtotime($payment->payment_date))}}</td>
-                                            </tr>
-                                        @endforeach
-                                @endif
-                                
-                                </tbody>
-
-                            </table>
-                        </div>
-
-                        <div class="row centerize mt-3 pt-3">
-                            <div class="col-md result text-muted"> 1-20 of 320 results</div>
-             
-                                <div class="pagination">
-                                    <a href="#">&laquo;</a>
-                                    <a class="active" href="#">1</a>
-                                    <a href="#">2</a>
-                                    <a href="#">3</a>
-                                    <a href="#">4</a>
-                                    <a href="#">...</a>
-                                    <a href="#">6</a>
-                                    <a href="#">&raquo;</a>
-                                </div>
-                          
-                        </div>
+                    <div id="tbl" class="container">
+                        @include('pages.ministry.pagination')
                     </div>
 
                 </div>

--- a/resources/views/pages/ministry/single.blade.php
+++ b/resources/views/pages/ministry/single.blade.php
@@ -126,7 +126,7 @@
                                         </section>                   
                                         <br>
                                         <section class="row">
-                                            <div class="col-12" style="position:relative">
+                                            <div class="col-12" >
                                             <i class="fa fa-calendar" aria-hidden="true"></i>
                                             <input placeholder="Select Date" name="select-date" id="select-date"  class="form-control">
                                             <input placeholder="Select Month" name="select-month" id="select-month" class="monthYearPicker form-control" />


### PR DESCRIPTION
Using Laravel default way of pagination was a no-no as that would trigger a page refresh causing date filter choices(if present) to be lost. So I had to figure out a way to do pagination without page reloads

![pagination](https://user-images.githubusercontent.com/45360667/87551026-ae0ac180-c6a7-11ea-8c81-aff7d3997579.PNG)

Also I have included a factory for seeding the db with payment data (which mirrors what is on the spreadsheets)