### PR TITLE
fixing color of and margin issues of breadcrumb links

### DIFF
--- a/public/css/contract_page.css
+++ b/public/css/contract_page.css
@@ -42,6 +42,23 @@
 	content: ".";
 	font-weight: var(--fw-bold);
 }
+.first{
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+.first li a{
+  color: #6c757d;
+}
+
+.first li a:hover{
+  text-decoration: none;
+  color: #00945E;
+}
+
+.first li.active{
+  color: #00945E;
+}
 h1{
   font-size: 36px;
   margin-top: 30px !important;

--- a/public/css/ministry_list.css
+++ b/public/css/ministry_list.css
@@ -128,6 +128,24 @@ body{
   top:13%;
 }
 
+.first{
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+.first li a{
+  color: #6c757d;
+}
+
+.first li a:hover{
+  text-decoration: none;
+  color: #00945E;
+}
+
+.first li.active{
+  color: #00945E;
+}
+
 @media only screen and (min-width:770px){
   .texts .num{
     color: #33A97E;


### PR DESCRIPTION
I just fixed the issue on #286 with respect to the header

(Just a few changes)
margin and color issues of the breadcrumb for contract and ministry list pages

![Screenshot from 2020-07-21 14-09-43](https://user-images.githubusercontent.com/52088600/88058788-e143c980-cb5b-11ea-91cd-b48aef7023e8.png)

