### PR TITLE
[BUG] on ministry and {ministries} [FIX]

### DIFF
--- a/resources/views/pages/ministry/cards.blade.php
+++ b/resources/views/pages/ministry/cards.blade.php
@@ -12,8 +12,7 @@
         <div class="coat">
         <img src="{{ asset('images/image 7.png') }}" alt="">
         <div class="text-center ministry">
-            <h4><b> {{ $ministry->name }} </b></h4>
-            <a title="Click to view profile" href="{{ route('ministries.single', $ministry->shortname) }}">{{$ministry->name}}</a>
+            <a title="Click to view profile" href="{{ route('ministries.single', $ministry->shortname) }}"><h4 style="color:#33A973"><b>{{$ministry->name}}</b></h4></a>
         </div>
         </div>
         <div class="texts d-flex flex-column text-center">

--- a/resources/views/pages/ministry/cards.blade.php
+++ b/resources/views/pages/ministry/cards.blade.php
@@ -12,7 +12,7 @@
         <div class="coat">
         <img src="{{ asset('images/image 7.png') }}" alt="">
         <div class="text-center ministry">
-            {{-- <h4>{{$ministry->name}}</h4> --}}
+            <h4><b> {{ $ministry->name }} </b></h4>
             <a title="Click to view profile" href="{{ route('ministries.single', $ministry->shortname) }}">{{$ministry->name}}</a>
         </div>
         </div>

--- a/resources/views/pages/ministry/single.blade.php
+++ b/resources/views/pages/ministry/single.blade.php
@@ -11,22 +11,7 @@
 
 @section('content')
 <!-- Section-->
-<div class="container mt-4 pt-2">
-    <div class="container mt-4">
-
-        <div class="row">
-            <p id="header" class="font-weight-bold">
-                <span class="head-cont text-success"> HOME</span>
-                <span class="head-cont dot"> &#8226</span>
-                <span class="head-cont text-success"> PROFILES</span>
-                <span class="head-cont dot"> &#8226</span>
-                <span class="head-cont text-success"> MINISTRIES</span>
-                <span class="head-cont dot"> &#8226</span>
-                <span class="head-cont text-success"> MINISTRY PROFILE</span>
-            </p>
-        </div>
-    </div>
-</div>
+{{ Breadcrumbs::render('ministry', $ministry) }}
 
 <div class="container d-flex centerize py-4">
     <div class="ministry-logo d-flex ">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43188489/88375040-c1e2b180-cd92-11ea-8408-a90c84528b20.png)
Now the title of the Ministry shows

![image](https://user-images.githubusercontent.com/43188489/88375169-fd7d7b80-cd92-11ea-8824-f90798bdfae4.png)
Current dynamic breadcrumb implemented (shows the title of the ministry)