### PR TITLE
Minor fixes

### DIFF
--- a/app/Payment.php
+++ b/app/Payment.php
@@ -47,4 +47,11 @@ class Payment extends Model
         }
         return $organization; //return array keyed ['name' => '', 'shortname' => '']
     }
+
+    public function company(){
+        $company = Company::select('*')
+                   ->where('name', $this->beneficiary)
+                   ->get();
+        return $company;
+    }
 }

--- a/public/js/chart.js
+++ b/public/js/chart.js
@@ -143,17 +143,19 @@ const insertCommas = amount =>{
   return parts.join(".");
 }
 
-window.addEventListener('load', renderChartsByMonths)
+window.addEventListener('load', function(event){
+      let ministryName = $('#ministry_list').val()
+      renderChartsByMonths(event, ministryName)
+})
+
 $('#ministry_list').on('change', renderChartsByMonths)
 
-function renderChartsByMonths(event){
-  let ministry = event.target.value || "agriculture";
-  console.log(ministry)
+function renderChartsByMonths(event, ministryName){
+  let ministry = event.target.value || ministryName;
   $.ajax({
       url: `/changeMinistryCharts/${ministry}`,
       method: "GET",
       success: function(data){
-        console.log(data)
         const {byMonths, byYears, byCompanies} = data;
           $('#annual-sum').html(insertCommas(byMonths.sum.toFixed(2)))
           $('.year-in-focus').html(byMonths.year) 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -182,14 +182,30 @@ $(".comp-card").click(function() {
     return false;
 });
 
-$(".ministry-stat").click(function() {
-    let ministry_list = document.getElementById('ministry_list');
-    let ministry = ministry_list.value;
+// $(".ministry-stat").click(function() {
+//     let ministry_list = document.getElementById('ministry_list');
+//     let ministry = ministry_list.value;
 
-    let ministry_card = document.getElementsByClassName('ministry-stat');
+//     let ministry_card = document.getElementsByClassName('ministry-stat');
+//     let link = document.getElementById('link');
+//     link.href = `/ministries/${ministry}`;
+//     window.location = $(this).find("a").attr("href"); 
+//     return false;
+// });
+
+$(".ministry-stat").click(function(e) {
+    console.log(e.target)
     let link = document.getElementById('link');
-    link.href = `/ministries/${ministry}`;
-    window.location = $(this).find("a").attr("href"); 
+    if(e.target.id !== 'top-company'){
+        let ministry_list = document.getElementById('ministry_list');
+        let ministry = ministry_list.value;           
+        link.href = `/ministries/${ministry}`;
+    }else{
+        let topCoy = $('#top-company').text()
+        let routeName = topCoy.replace(/\s/g, '-')
+        link.href = `/contractors/${routeName}`
+    }
+    window.location = $(this).find("a").attr("href");
     return false;
 });
 

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -182,17 +182,6 @@ $(".comp-card").click(function() {
     return false;
 });
 
-// $(".ministry-stat").click(function() {
-//     let ministry_list = document.getElementById('ministry_list');
-//     let ministry = ministry_list.value;
-
-//     let ministry_card = document.getElementsByClassName('ministry-stat');
-//     let link = document.getElementById('link');
-//     link.href = `/ministries/${ministry}`;
-//     window.location = $(this).find("a").attr("href"); 
-//     return false;
-// });
-
 $(".ministry-stat").click(function(e) {
     console.log(e.target)
     let link = document.getElementById('link');

--- a/public/js/report_chart.js
+++ b/public/js/report_chart.js
@@ -57,7 +57,10 @@ let options = {
         },
         labels:{
             minWidth: 0,
-            maxWidth: 160
+            maxWidth: 160,
+            formatter: function(val){
+                return val.toFixed(2)
+            }
         }
     },
     noData: {


### PR DESCRIPTION
**Ministry Expenditure Chart on Home Page:**
1) Top beneficiary name is now clickable. Clicking on top beneficiary's name now will take you to their contractor profile. Clicking anywhere else on the ministry card will still take you to that ministry's profile

2) Also fixed a bug I observed with top beneficiary chart not grouping beneficiaries properly.

**Expense/Report Chart**
Formatted the y-axis labels to display figures to 2 d.p.