### PR TITLE
Contractors charts don't show when company begins with a number

### DIFF
--- a/resources/views/pages/contract/index.blade.php
+++ b/resources/views/pages/contract/index.blade.php
@@ -70,7 +70,7 @@
                 <div class="card-body">
                     <chart label="myVueChart"
                             v-bind:data="[{amount: {{round($contractor->total_amount / 12)}}, year: {{$contractor->year}} }, {amount:{{$contractor->total_amount}}, year:{{$contractor->year}} }]"
-                            element="{{ \Str::slug($contractor->beneficiary, '-') . $loop->index }}"></chart>
+                            element="{{ 'id-'. \Str::slug($contractor->beneficiary, '-') . $loop->index }}"></chart>
                     <div class="contractor mb-2">
                         <!-- <img src="{{ asset('images/image 13.png') }}" height="30" class="mr-3" alt=""> -->
                         <a href="{{ route('contractors.single', ['company' => str_replace(' ', '-', $contractor->beneficiary) ]) }}">


### PR DESCRIPTION
Before
![company charts don't show](https://user-images.githubusercontent.com/45360667/89151166-38806b80-d558-11ea-9da8-0a7a15912c13.PNG)

Now
![company charts fixed](https://user-images.githubusercontent.com/45360667/89151168-39b19880-d558-11ea-8d79-367a6ad4b5a1.PNG)
