### PR TITLE
Reset and Sort only functionality to ministry profile date filter

### DIFF
--- a/app/Http/Controllers/MinistryController.php
+++ b/app/Http/Controllers/MinistryController.php
@@ -140,14 +140,10 @@ class MinistryController extends Controller
     {
         $code = $ministry->code;
         $cabinets = $ministry->cabinet;
-        // $date = date('Y-m-d');
-        $date = date('Y');
-        $ministries = Ministry::select('id', 'shortname')
-                    ->orderby('shortname', 'asc')
-                    ->get();
+        $date = date('Y-m-d');
         $payments = DB::table('payments')
             ->where('payment_code', 'LIKE', "$code%")
-            ->whereYear('payment_date', '=', "$date")
+            ->whereDate('payment_date', '=', "$date")
             ->orderby('payment_date', 'desc')
             ->paginate(10);
 
@@ -158,7 +154,6 @@ class MinistryController extends Controller
             'payments' => $payments,
             'trend' => $data[1],
             'count' => $data[0],
-            'ministries' => $ministries
         ]);
     }
 

--- a/app/Http/Controllers/MinistryController.php
+++ b/app/Http/Controllers/MinistryController.php
@@ -139,13 +139,16 @@ class MinistryController extends Controller
     {
         $code = $ministry->code;
         $cabinets = $ministry->cabinet;
-        $date = date('Y-m-d');
-
+        // $date = date('Y-m-d');
+        $date = date('Y');
+        $ministries = Ministry::select('id', 'shortname')
+                    ->orderby('shortname', 'asc')
+                    ->get();
         $payments = DB::table('payments')
             ->where('payment_code', 'LIKE', "$code%")
-            ->whereDate('payment_date', '=', "$date")
+            ->whereYear('payment_date', '=', "$date")
             ->orderby('payment_date', 'desc')
-            ->paginate(2);
+            ->paginate(10);
 
         $data = $this->fiveYearTrend($code);
         return view('pages.ministry.single')->with([
@@ -154,6 +157,7 @@ class MinistryController extends Controller
             'payments' => $payments,
             'trend' => $data[1],
             'count' => $data[0],
+            'ministries' => $ministries
         ]);
     }
 

--- a/app/Http/Controllers/MinistrySearchController.php
+++ b/app/Http/Controllers/MinistrySearchController.php
@@ -11,7 +11,7 @@ class MinistrySearchController extends Controller
     public function filterExpenses(Request $request)
     {
         $id = $request->query('id');
-        $today = date("Y");
+        $today = date("Y-m-d");
         $givenTime = null;
         if ($request->has('date')) {
             $givenTime = $request->query('date');
@@ -43,7 +43,7 @@ class MinistrySearchController extends Controller
         } else {
             $payments = DB::table('payments')
                     ->where('payment_code', 'LIKE', "$code%")
-                    ->whereYear('payment_date', '>=', $today);
+                    ->whereDate('payment_date', '>=', $today);
         };
 
         if ($request->has('sort')) {

--- a/app/Http/Controllers/MinistrySearchController.php
+++ b/app/Http/Controllers/MinistrySearchController.php
@@ -11,12 +11,13 @@ class MinistrySearchController extends Controller
     public function filterExpenses(Request $request)
     {
         $id = $request->query('id');
+        $today = date("Y");
         $givenTime = null;
         if ($request->has('date')) {
             $givenTime = $request->query('date');
         }
 
-        $yr = date("Y");
+       
         $ministry = Ministry::find($id);
         $code = $ministry->code;
         $day_pattern = '/(\d{4})-(\d{2})-(\d{2})/';
@@ -42,7 +43,7 @@ class MinistrySearchController extends Controller
         } else {
             $payments = DB::table('payments')
                     ->where('payment_code', 'LIKE', "$code%")
-                    ->whereYear('payment_date', '>=', "$yr");
+                    ->whereYear('payment_date', '>=', $today);
         };
 
         if ($request->has('sort')) {
@@ -51,7 +52,7 @@ class MinistrySearchController extends Controller
             $payments = $payments->orderby('payment_date', 'desc');
         }
         
-        $payments = $payments->paginate(2);
+        $payments = $payments->paginate(10);
        
         return view('pages.ministry.pagination')
         ->with(['ministry'=> $ministry,

--- a/public/js/ministry_profile.js
+++ b/public/js/ministry_profile.js
@@ -96,7 +96,6 @@ $(document).ready(function() {
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////
-    console.log('connected')
      $('.tabs').click(function() {
             $('.tabs.active').removeClass("active");
             $(this).addClass("active");
@@ -132,7 +131,6 @@ $(document).ready(function() {
             date = "undefined";
             sort = undefined;
             const data = {id, date, sort};
-           console.log('data: ', data);
             $(this).closest('.modal-content').find('.byDatePicker').val('')
             $(this).closest('.modal-content').find('.monthYearPicker').val('')
             $(this).closest('.modal-content').find('.yearPicker').val('')
@@ -151,7 +149,6 @@ $(document).ready(function() {
                     // console.log(data)
                     const table = e.target.closest('#modal').nextElementSibling;
                     const tableDate = table.closest('.main-table').querySelector('.said-date-caption');
-                    console.log('tabledate', tableDate)
                     table.innerHTML = data;
                     tableDate.innerHTML = `Date: ${defaultTableDate}`;
                     tableOneIsModified = false;         
@@ -165,8 +162,6 @@ $(document).ready(function() {
         $('#apply-filter').on('click', function(e){
             const id = $(this).attr("data-id");
             const idjs = e.target.dataset.id;
-            console.log('id: ', id)
-            console.log('idjs: ', idjs)
             let invalid = false;
             
            
@@ -235,7 +230,7 @@ $(document).ready(function() {
             if(sort !== undefined){
                 data.sort = sort;
             }
-           console.log('data: ', data);
+           
             $.ajax({
                     url: "/ministry/filterExpenses",
                     method: "GET",
@@ -244,7 +239,6 @@ $(document).ready(function() {
                         
                         $('#tbl').html(data)
                         const tableDate = document.querySelector('.said-date-caption')
-                        console.log('table', tableDate)
                         if(date !== 'undefined'){
                             let reportDate = /\d{4}-\d{2}-\d{2}/.test(date)? formatDate(date) : date;
                             tableDate.innerHTML = `Showing expenses for <span style="color:#1e7e34">${reportDate}</span>`;

--- a/resources/views/pages/ministry/pagination.blade.php
+++ b/resources/views/pages/ministry/pagination.blade.php
@@ -22,7 +22,11 @@
                 $shade = $back ? 'back': '';
                 @endphp
                     <tr  class="{{$shade}}">
-                        <td> {{$payment->description}}</td>
+                        @if($payment->description)
+                        <td>{{$payment->description}}</td>
+                        @else
+                        <td class="text-danger">Not Stated</td>
+                        @endif
                         <td> {{$payment->beneficiary}}</td>
                         <td> ₦{{number_format($payment->amount, 2)}}</td>
                         <td> {{date('jS, M Y', strtotime($payment->payment_date))}}</td>

--- a/resources/views/pages/ministry/single.blade.php
+++ b/resources/views/pages/ministry/single.blade.php
@@ -286,16 +286,9 @@
     </div>
 
     <div class="form-group">
-      <label for="ministry">Select Cabinet</label>
-      <select id="inputState" class="form-control" name="ministry_id">
-        {{-- <option class="mb-1" value="{{$ministry->id}}">{{$ministry->shortname}}</option> --}}
-        @foreach ($ministries as $current)
-            @if($ministry->id == $current->id)
-                <option class="mb-1" selected value="{{$current->id}}">{{$current->shortname}}</option>
-            @else
-                <option class="mb-1" value="{{$current->id}}">{{$current->shortname}}</option>
-            @endif
-        @endforeach
+      <label for="ministry">Ministry</label>
+      <select id="inputState" readonly class="form-control" name="ministry_id">
+        <option class="mb-1"  value="{{$ministry->id}}">{{$ministry->shortname}}</option>
       </select>
     </div>
    <center>

--- a/resources/views/pages/ministry/single.blade.php
+++ b/resources/views/pages/ministry/single.blade.php
@@ -51,7 +51,7 @@
             <small>{{date('Y')}}</small>
         </div>
         <div class="col">
-            <p>Total Number of Projects</p>
+            <p>Total Number of Payouts</p>
             <h4><span class="text-success">{{$count}}</span></h4>
             <small>{{date('Y')}}</small>
         </div>
@@ -74,13 +74,13 @@
         <!--1-->
         <div id="expense" class="tab-pane fade show active">
 
-            <div>
+            <div class="main-table">
                 <div id="table-border" class="container pt-3 mt-4 pb-3">
                     <div class="container pb-3 pt-1 py-4">
                         <div class="row centerize">
                             <div class="col">
                             <!-- Test -->
-                                <h3 id="said-date" class="index">Showing Expenses For {{date("jS F, Y")}}</h3>
+                                <h3 class="said-date-caption" class="align-self-center">Date: <span class="said-date">{{ date("dS, M Y") }}</span></h3>
                             </div>
 
                             <div class="col">
@@ -124,7 +124,7 @@
                                         <section class="row">
                                             <div class="col-12" >
                                             <i class="fa fa-calendar" aria-hidden="true"></i>
-                                            <input placeholder="Select Date" name="select-date" id="select-date"  class="form-control">
+                                            <input placeholder="Select Date" name="select-date" id="select-date"  class="byDatePicker form-control">
                                             <input placeholder="Select Month" name="select-month" id="select-month" class="monthYearPicker form-control" />
                                             <input placeholder="Select Year" name="select-year" id="select-year" class="yearPicker form-control" />
                                             <small id="date-format-err"></small>
@@ -140,6 +140,7 @@
                                     </div>
                                     <!-- Footer -->
                                     <div class="modal-footer">
+                                    <button type="button" data-id="{{$ministry->id}}" id="reset" class="btn btn-block active mx-5 reset btn-danger">Reset</button>
                                     <button type="button" data-id="{{$ministry->id}}" id="apply-filter" class="btn btn-block active mx-5" data-dismiss="modal">Apply Filter</button>
                                     </div>
                                 </div>
@@ -287,26 +288,14 @@
     <div class="form-group">
       <label for="ministry">Select Cabinet</label>
       <select id="inputState" class="form-control" name="ministry_id">
-        <option selected value="1">Works</option>
-        <option value="Housing">Housing</option>
-        <option value="Interior">Interior</option>
-        <option value="Petroleum">Petroleum</option>
-        <option value="Finance">Finance</option>
-        <option value="Power">Power</option>
-        <option value="Health">Health</option>
-        <option value="Labour">Labour</option>
-        <option value="Environment">Environment</option>
-        <option value="Water Resouirces">Water Resouirces</option>
-        <option value="Communication">Communication</option>
-        <option value="Aviation">Aviation</option>
-        <option value="Defense">Defense</option>
-        <option value="Information">Information</option>
-        <option value="Youths and Sports">Youths and Sports</option>
-        <option value="Police Affairs">Police Affairs</option>
-        <option value="Education">Education</option>
-        <option value="Justice">Justice</option>
-        <option value="Agriculture">Agriculture</option>
-        <option value="Women Affairs">Women Affairs</option>
+        {{-- <option class="mb-1" value="{{$ministry->id}}">{{$ministry->shortname}}</option> --}}
+        @foreach ($ministries as $current)
+            @if($ministry->id == $current->id)
+                <option class="mb-1" selected value="{{$current->id}}">{{$current->shortname}}</option>
+            @else
+                <option class="mb-1" value="{{$current->id}}">{{$current->shortname}}</option>
+            @endif
+        @endforeach
       </select>
     </div>
    <center>


### PR DESCRIPTION
Ministry profile date filter didn't have reset functionality neither could you sort alone without choosing a date. The above issues have been fixed. 

Also I have made the select option  of suggest a cabinet member default to the ministry the user is currently on and readonly. This is how it looks

![suggestion](https://user-images.githubusercontent.com/45360667/89325182-5517c300-d680-11ea-8872-978b34c6c7b2.PNG)
